### PR TITLE
GLIDE-50 #time 1h #comment Pagination now works based on Time, using …

### DIFF
--- a/constant/constants.go
+++ b/constant/constants.go
@@ -13,3 +13,6 @@ const IgcMetadata = "igc-metadata"
 
 // PageSize - Size of a page in a Firestore Query
 const PageSize = 20
+
+// FirebaseQueryOrder - What to order the Firestore Query with (time)
+const FirebaseQueryOrder = "Time"

--- a/endpoints-routes-v1.0.yml
+++ b/endpoints-routes-v1.0.yml
@@ -111,19 +111,15 @@
       type: string
       description: Requesting user id
       required: true
-    - name: page
+    - name: timeSkip
       type: string
-      description: Requested page
+      description: Skip to after this timestamp
       required: false (default = 1)
     - name: queryType
       type: string
       description: Type of query to be made
       available: Private, Public
       required: false (default = Public)
-    - name: order (DISABLED)
-      type: string
-      description: What to order the search on
-      required: false (default = Time)
     - name: orderDirection
       type: string
       description: Direction of the order

--- a/rest/dbHandler.go
+++ b/rest/dbHandler.go
@@ -58,12 +58,12 @@ func (dbHandler DbHandler) insertTrackRecordPage(w http.ResponseWriter, r *http.
 func (dbHandler DbHandler) getTracksPage(w http.ResponseWriter, r *http.Request) {
 	// Extract data from header
 	uID := r.Header.Get("uid")
-	pg := r.Header.Get("page")
+	tmsk := r.Header.Get("timeSkip")
 	qt := r.Header.Get("queryType")
 	ordDir := r.Header.Get("orderDirection")
 
 	// Process request
-	d, err := GetTracks(dbHandler.Ctx.App, models.NewFirebaseQuery(uID, pg, qt, "Time", ordDir))
+	d, err := GetTracks(dbHandler.Ctx.App, models.NewFirebaseQuery(uID, tmsk, qt, ordDir))
 	if err != nil {
 		gtbackend.DebugLog(fileNameDB, "getTracksPage", err)
 

--- a/rest/firebaseQueryHandler_test.go
+++ b/rest/firebaseQueryHandler_test.go
@@ -19,7 +19,7 @@ func TestGetTracks(t *testing.T) {
 	}
 
 	testUID := "iP1dgAHJ2JNce4hGr9H0RugkCHP2"
-	privateQ := models.NewFirebaseQuery(testUID, "1", "Private", "Time", "Asc")
+	privateQ := models.NewFirebaseQuery(testUID, "1", "Private", "Asc")
 
 	res, err := GetTracks(app, privateQ)
 	if err != nil {
@@ -34,7 +34,7 @@ func TestGetTracks(t *testing.T) {
 		}
 	}
 
-	publicQ := models.NewFirebaseQuery(testUID, "1", "Public", "Time", "Asc")
+	publicQ := models.NewFirebaseQuery(testUID, "1", "Public", "Asc")
 
 	res, err = GetTracks(app, publicQ)
 	if err != nil {


### PR DESCRIPTION
…startAfter and the timestamp as int to properly start the page. Also removed Order as it is unlikely we will ever use it, or that any other ordering would even make sense.