### PR TITLE
Fix on scraper UID

### DIFF
--- a/constant/constants.go
+++ b/constant/constants.go
@@ -24,7 +24,7 @@ const FirebaseQueryOrder = "Time"
 const MaxIgcFileSize = 15 * 1024 * 1024
 
 // ScraperUID - Scraper UID
-const ScraperUID = "Hvl8FlvVz6QSKkNjsDeLB5aKBmA2"
+const ScraperUID = "iP1dgAHJ2JNce4hGr9H0RugkCHP2"
 
 // TestUID - E2E Test UID
 const TestUID = "o1Sz791YSHby0PCe51JlxSD6G533"

--- a/rest/firebaseQueryHandler_test.go
+++ b/rest/firebaseQueryHandler_test.go
@@ -10,8 +10,7 @@ import (
 func TestGetTracks(t *testing.T) {
 	app := testutils.InitializeFirebaseTest()
 
-	testUID := "iP1dgAHJ2JNce4hGr9H0RugkCHP2"
-	privateQ := models.NewFirebaseQuery(testUID, "1", "Private", "Asc")
+	privateQ := models.NewFirebaseQuery(constant.TestUID, "1", "Private", "Asc")
 
 	res, err := GetTracks(app, privateQ)
 	if err != nil {
@@ -21,12 +20,12 @@ func TestGetTracks(t *testing.T) {
 		t.Error("GetTracks private test with no results!")
 	}
 	for i := 0; len(res) < i; i++ {
-		if res[i].UID != testUID {
+		if res[i].UID != constant.TestUID {
 			t.Error("GetTracks non-testUID data in private query!")
 		}
 	}
 
-	publicQ := models.NewFirebaseQuery(testUID, "1", "Public", "Asc")
+	publicQ := models.NewFirebaseQuery(constant.TestUID, "1", "Public", "Asc")
 
 	res, err = GetTracks(app, publicQ)
 	if err != nil {
@@ -36,7 +35,7 @@ func TestGetTracks(t *testing.T) {
 		t.Error("GetTracks public test with no results!")
 	}
 	for i := 0; len(res) < i; i++ {
-		if res[i].UID == testUID {
+		if res[i].UID == constant.TestUID {
 			t.Error("GetTracks testUID data in public query!")
 		}
 	}


### PR DESCRIPTION
Quickly replacing the scraper UID in constants, and one test that was using it in testing when it should not be the scraper.